### PR TITLE
GH-127 allow to exclude paths

### DIFF
--- a/yang-lsp/io.typefox.yang.diagram/src/main/java/io/typefox/yang/diagram/RunSocketServer.xtend
+++ b/yang-lsp/io.typefox.yang.diagram/src/main/java/io/typefox/yang/diagram/RunSocketServer.xtend
@@ -28,6 +28,8 @@ import org.eclipse.xtext.ide.server.LanguageServerImpl
 import org.eclipse.xtext.ide.server.ServerModule
 import org.eclipse.xtext.resource.IResourceServiceProvider
 import org.eclipse.xtext.util.Modules2
+import org.eclipse.xtext.ide.server.ProjectManager
+import io.typefox.yang.ide.server.YangProjectManager
 
 class RunSocketServer {
 	
@@ -47,6 +49,7 @@ class RunSocketServer {
 		
 		val injector = Guice.createInjector(Modules2.mixin(new ServerModule, [
 			bind(IResourceServiceProvider.Registry).toProvider(IResourceServiceProvider.Registry.RegistryProvider)
+			bind(ProjectManager).to(YangProjectManager)
 		]))
 		val serverSocket = AsynchronousServerSocketChannel.open.bind(new InetSocketAddress("localhost", 5007))
 		val threadPool = Executors.newCachedThreadPool()

--- a/yang-lsp/io.typefox.yang.diagram/src/main/java/io/typefox/yang/diagram/YangServerLauncher.xtend
+++ b/yang-lsp/io.typefox.yang.diagram/src/main/java/io/typefox/yang/diagram/YangServerLauncher.xtend
@@ -14,6 +14,7 @@ import io.typefox.sprotty.server.json.ActionTypeAdapter
 import io.typefox.yang.YangRuntimeModule
 import io.typefox.yang.ide.YangIdeModule
 import io.typefox.yang.ide.YangIdeSetup
+import io.typefox.yang.ide.server.YangProjectManager
 import java.util.concurrent.Executors
 import java.util.function.Consumer
 import java.util.function.Function
@@ -32,6 +33,7 @@ import org.eclipse.lsp4j.services.LanguageClient
 import org.eclipse.xtend.lib.annotations.Data
 import org.eclipse.xtext.ide.server.LanguageServerImpl
 import org.eclipse.xtext.ide.server.LaunchArgs
+import org.eclipse.xtext.ide.server.ProjectManager
 import org.eclipse.xtext.ide.server.ServerLauncher
 import org.eclipse.xtext.ide.server.ServerModule
 import org.eclipse.xtext.resource.IResourceServiceProvider
@@ -55,6 +57,7 @@ class YangServerLauncher extends ServerLauncher {
 		launch(ServerLauncher.name, args, Modules2.mixin(new ServerModule, [
 			bind(ServerLauncher).to(YangServerLauncher)
 			bind(IResourceServiceProvider.Registry).toProvider(IResourceServiceProvider.Registry.RegistryProvider)
+			bind(ProjectManager).to(YangProjectManager)
 		]))
 	}
 

--- a/yang-lsp/io.typefox.yang.ide/src/main/java/io/typefox/yang/ide/server/YangExclusionProvider.xtend
+++ b/yang-lsp/io.typefox.yang.ide/src/main/java/io/typefox/yang/ide/server/YangExclusionProvider.xtend
@@ -1,0 +1,44 @@
+package io.typefox.yang.ide.server
+
+import io.typefox.yang.settings.PreferenceValuesProvider
+import java.util.Map
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.preferences.IPreferenceValues
+import org.eclipse.xtext.preferences.PreferenceKey
+import io.typefox.yang.settings.JsonFileBasedPreferenceValues
+
+class YangExclusionProvider {
+	
+	static val EXCLUSION_PATHS = new PreferenceKey("excludePath", "")
+
+	Map<URI, IPreferenceValues> preferences = newHashMap
+	
+	def isExcluded(URI uri, URI projectURI) {
+		val uriAsString = uri.toString
+		val excludedSegments = getPreferences(projectURI).getPreference(EXCLUSION_PATHS) 
+		if (excludedSegments !== null && !excludedSegments.empty) {
+			val truncatedProjectURI = if (projectURI.lastSegment.empty) projectURI.trimSegments(1) else projectURI 
+			val excludedPaths = excludedSegments.split(':').map[ path |
+				truncatedProjectURI
+					.appendSegments(path.split('/').filter[!empty])
+					.appendSegment('')
+					.toString
+			]
+			return excludedPaths.exists[
+				uriAsString.startsWith(it)
+			]
+		}
+		return false
+	}
+
+	private def getPreferences(URI projectURI) {
+		val prefs = preferences.get(projectURI) ?: {
+			val newPrefs = PreferenceValuesProvider.createPreferenceValues(projectURI)
+			preferences.put(projectURI, newPrefs)
+			newPrefs
+		}
+		if (prefs instanceof JsonFileBasedPreferenceValues)
+			prefs.checkIsUpToDate
+		prefs
+	}
+}

--- a/yang-lsp/io.typefox.yang.ide/src/main/java/io/typefox/yang/ide/server/YangProjectManager.xtend
+++ b/yang-lsp/io.typefox.yang.ide/src/main/java/io/typefox/yang/ide/server/YangProjectManager.xtend
@@ -1,0 +1,22 @@
+package io.typefox.yang.ide.server
+
+import com.google.inject.Inject
+import java.util.List
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.ide.server.ProjectManager
+import org.eclipse.xtext.resource.IResourceDescription.Delta
+import org.eclipse.xtext.util.CancelIndicator
+
+class YangProjectManager extends ProjectManager {
+	
+	@Inject extension YangExclusionProvider 
+	
+	override protected newBuildRequest(List<URI> changedFiles, List<URI> deletedFiles, List<Delta> externalDeltas, CancelIndicator cancelIndicator) {
+		val request = super.newBuildRequest(changedFiles, deletedFiles, externalDeltas, cancelIndicator)
+		request.dirtyFiles = changedFiles.filter [
+			!isExcluded(baseDir)
+		].toList
+		request
+	}
+	
+}

--- a/yang-lsp/io.typefox.yang.ide/yang.settings
+++ b/yang-lsp/io.typefox.yang.ide/yang.settings
@@ -1,0 +1,3 @@
+{
+	"excludePath": "build:bin" 
+}

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/settings/JsonFileBasedPreferenceValues.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/settings/JsonFileBasedPreferenceValues.xtend
@@ -30,7 +30,7 @@ class JsonFileBasedPreferenceValues extends MapBasedPreferenceValues {
 	 * reloads the preferences from disk if the file has changed.
 	 * @return whether
 	 */
-	public def boolean checkIsUpToDate() {
+	def boolean checkIsUpToDate() {
 		var result = true
 		val d = this.delegate
 		if (d instanceof JsonFileBasedPreferenceValues) {
@@ -45,7 +45,7 @@ class JsonFileBasedPreferenceValues extends MapBasedPreferenceValues {
 			}
 		} catch (Exception e) {
 			if (!(e instanceof NoSuchFileException)) {
-				LOG.error("Error reading settings '"+path+"' : "+e.message)
+				LOG.error("Error reading settings '" + path + "' : " + e.message)
 			} else {
 				lastModification = null
 			}

--- a/yang-lsp/io.typefox.yang/yang.settings
+++ b/yang-lsp/io.typefox.yang/yang.settings
@@ -1,0 +1,3 @@
+{
+	"excludePath": "build:bin" 
+}


### PR DESCRIPTION
The property `excludePath` in the `yang.settings` JSON file can now point to a colon separated list of excluded directories, e.g.

    {
       "excludePath": "build/classes:bin/foo" 
    }

Path separator is always `/`
