### PR TITLE
Fix Proposal for GH132 issue, customize search scope when XpathExpression is defined in grouping

### DIFF
--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/validation/SubstatementRuleProvider.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/validation/SubstatementRuleProvider.xtend
@@ -182,8 +182,8 @@ class SubstatementRuleProvider {
 		.any(TYPEDEF)
 		.any(GROUPING)
 		.with(DATA_RULE)
-		.optional(YANG_1_1, ACTION)
-		.optional(YANG_1_1, NOTIFICATION);
+		.any(YANG_1_1, ACTION)
+		.any(YANG_1_1, NOTIFICATION);
 
 	static val CONTAINER_RULE = newRule()
 		.optional(WHEN)
@@ -382,7 +382,7 @@ class SubstatementRuleProvider {
 		.optional(UNITS)
 		.any(MUST)
 		.any(UNIQUE)
-		.optional(DEFAULT)
+		.any(DEFAULT)
 		.optional(CONFIG)
 		.optional(MANDATORY)
 		.optional(MIN_ELEMENTS)


### PR DESCRIPTION
I spent 2 days to understand how ScopeContext, Resolve and Linker works together.
Finally, I think to remove LocalNodeScopeContext of Grouping is not correct.

So I customize the search scope of XpathExpression Resolver when the XpathExpression is defined in Grouping.