### PR TITLE
GH-149: Added name support for revision statements.

### DIFF
--- a/yang-lsp/io.typefox.yang.ide/src/main/java/io/typefox/yang/ide/symbols/YangDocumentSymbolNameProvider.xtend
+++ b/yang-lsp/io.typefox.yang.ide/src/main/java/io/typefox/yang/ide/symbols/YangDocumentSymbolNameProvider.xtend
@@ -1,8 +1,11 @@
 package io.typefox.yang.ide.symbols
 
+import com.google.common.collect.Lists
 import io.typefox.yang.utils.YangNameUtils
 import io.typefox.yang.yang.Augment
+import io.typefox.yang.yang.Revision
 import io.typefox.yang.yang.SchemaNode
+import io.typefox.yang.yang.Unknown
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.xtext.ide.server.symbol.DocumentSymbolMapper.DocumentSymbolNameProvider
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils
@@ -14,8 +17,25 @@ class YangDocumentSymbolNameProvider extends DocumentSymbolNameProvider {
 			return object.name ?: object.yangName;
 		} else if (object instanceof Augment) {
 			return NodeModelUtils.findActualNodeFor(object.path).text.trim ?: object.yangName;
+		} else if (object instanceof Revision) {
+			return object.revision;
+		} else if (object instanceof Unknown) {
+			val name = super.getName(object);
+			// Insert the name of the `extension` before the name of the current statement and after the name of the prefix.
+			// https://github.com/theia-ide/yang-lsp/issues/149#issuecomment-437855640
+			if (!name.nullOrEmpty && name.contains('.')) {
+				val segments = Lists.newArrayList(name.split('\\.'));
+				if (segments.last == object.name) {
+					val extensionName = getName(object.extension);
+					if (!extensionName.nullOrEmpty) {
+						segments.add(segments.length - 1, extensionName);
+						return segments.join('.');
+					}
+				}
+
+			}
 		}
-		super.getName(object);
+		return super.getName(object);
 	}
 
 	protected def String getYangName(Object clazz) {

--- a/yang-lsp/io.typefox.yang.ide/src/test/java/io/typefox/yang/tests/symbols/DocumentSymbolsTest.xtend
+++ b/yang-lsp/io.typefox.yang.ide/src/test/java/io/typefox/yang/tests/symbols/DocumentSymbolsTest.xtend
@@ -5,56 +5,56 @@ import org.junit.Test
 
 class DocumentSymbolsTest extends AbstractYangLSPTest {
 	
-	@Test def void testEmpty() {		
+	@Test def void testEmpty() {
 		testDocumentSymbol[
-	            model = '''
-	            '''
-	    ]
+			model = '''
+			'''
+		]
 	}
-	
-	@Test def void testInputOutput() {		
+
+	@Test def void testInputOutput() {
 		testDocumentSymbol[
-            model = '''
-					module foo {
-						rpc myAction {
-							input {
-								leaf x { type string; }
-							}
-							output {
-								leaf x { type string; }
-							}
+			model = '''
+				module foo {
+					rpc myAction {
+						input {
+							leaf x { type string; }
+						}
+						output {
+							leaf x { type string; }
 						}
 					}
-            '''
-            expectedSymbols = '''
-					symbol "myAction" {
-					    kind: 6
-					    location: MyModel.yang [[1, 5] .. [1, 13]]
-					}
-					symbol "input" {
-					    kind: 7
-					    location: MyModel.yang [[2, 2] .. [2, 7]]
-					    container: "myAction"
-					}
-					symbol "x" {
-					    kind: 13
-					    location: MyModel.yang [[3, 8] .. [3, 9]]
-					    container: "input"
-					}
-					symbol "output" {
-					    kind: 9
-					    location: MyModel.yang [[5, 2] .. [5, 8]]
-					    container: "myAction"
-					}
-					symbol "x" {
-					    kind: 13
-					    location: MyModel.yang [[6, 8] .. [6, 9]]
-					    container: "output"
-					}
-					'''
-	    ]
+				}
+			'''
+			expectedSymbols = '''
+				symbol "myAction" {
+					kind: 6
+					location: MyModel.yang [[1, 5] .. [1, 13]]
+				}
+				symbol "input" {
+					kind: 7
+					location: MyModel.yang [[2, 2] .. [2, 7]]
+					container: "myAction"
+				}
+				symbol "x" {
+					kind: 13
+					location: MyModel.yang [[3, 8] .. [3, 9]]
+					container: "input"
+				}
+				symbol "output" {
+					kind: 9
+					location: MyModel.yang [[5, 2] .. [5, 8]]
+					container: "myAction"
+				}
+				symbol "x" {
+					kind: 13
+					location: MyModel.yang [[6, 8] .. [6, 9]]
+					container: "output"
+				}
+				'''
+		]
 	}
-	
+
 	@Test def void testDocumentSymbols() {
 		testDocumentSymbol[
 			model = '''
@@ -79,41 +79,140 @@ class DocumentSymbolsTest extends AbstractYangLSPTest {
 			'''
 			expectedSymbols = '''
 				symbol "x" {
-				    kind: 5
-				    location: MyModel.yang [[1, 10] .. [1, 11]]
+					kind: 5
+					location: MyModel.yang [[1, 10] .. [1, 11]]
 				}
 				symbol "bla" {
-				    kind: 3
-				    location: MyModel.yang [[5, 11] .. [5, 14]]
+					kind: 3
+					location: MyModel.yang [[5, 11] .. [5, 14]]
 				}
 				symbol "test" {
-				    kind: 13
-				    location: MyModel.yang [[6, 7] .. [6, 11]]
-				    container: "bla"
+					kind: 13
+					location: MyModel.yang [[6, 7] .. [6, 11]]
+					container: "bla"
 				}
 				symbol "bla2" {
-				    kind: 3
-				    location: MyModel.yang [[7, 12] .. [7, 16]]
-				    container: "bla"
+					kind: 3
+					location: MyModel.yang [[7, 12] .. [7, 16]]
+					container: "bla"
 				}
 				symbol "test2" {
-				    kind: 13
-				    location: MyModel.yang [[8, 8] .. [8, 13]]
-				    container: "bla2"
+					kind: 13
+					location: MyModel.yang [[8, 8] .. [8, 13]]
+					container: "bla2"
 				}
 				symbol "myIdentity" {
-				    kind: 14
-				    location: MyModel.yang [[12, 10] .. [12, 20]]
+					kind: 14
+					location: MyModel.yang [[12, 10] .. [12, 20]]
 				}
 				symbol "myType" {
-				    kind: 10
-				    location: MyModel.yang [[13, 9] .. [13, 15]]
+					kind: 10
+					location: MyModel.yang [[13, 9] .. [13, 15]]
 				}
 				symbol "someFeature" {
-				    kind: 17
-				    location: MyModel.yang [[16, 9] .. [16, 20]]
+					kind: 17
+					location: MyModel.yang [[16, 9] .. [16, 20]]
 				}
 			'''
 		]	
 	}
+
+	@Test def void testGH_149() {
+		testDocumentSymbol[
+			model = '''
+				module abc {
+					yang-version 1.1;
+					namespace abc;
+					prefix a;
+					revision 2018-10-10 {	
+						a:version 4;
+						a:release 5;
+						a:correction 6;
+					}
+					revision 2018-09-10 {
+						a:version 1;
+						a:release 2;
+						a:correction 3;
+					}
+					extension version {
+						argument value;
+					}
+					extension release {
+						argument value;
+					}
+					extension correction {
+						argument value;
+					}
+				}
+			'''
+			expectedSymbols = '''
+				symbol "2018-10-10" {
+					kind: 8
+					location: MyModel.yang [[4, 1] .. [4, 9]]
+				}
+				symbol "abc.version.4" {
+					kind: 8
+					location: MyModel.yang [[5, 12] .. [5, 13]]
+					container: "2018-10-10"
+				}
+				symbol "abc.release.5" {
+					kind: 8
+					location: MyModel.yang [[6, 12] .. [6, 13]]
+					container: "2018-10-10"
+				}
+				symbol "abc.correction.6" {
+					kind: 8
+					location: MyModel.yang [[7, 15] .. [7, 16]]
+					container: "2018-10-10"
+				}
+				symbol "2018-09-10" {
+					kind: 8
+					location: MyModel.yang [[9, 1] .. [9, 9]]
+				}
+				symbol "abc.version.1" {
+					kind: 8
+					location: MyModel.yang [[10, 12] .. [10, 13]]
+					container: "2018-09-10"
+				}
+				symbol "abc.release.2" {
+					kind: 8
+					location: MyModel.yang [[11, 12] .. [11, 13]]
+					container: "2018-09-10"
+				}
+				symbol "abc.correction.3" {
+					kind: 8
+					location: MyModel.yang [[12, 15] .. [12, 16]]
+					container: "2018-09-10"
+				}
+				symbol "version" {
+					kind: 2
+					location: MyModel.yang [[14, 11] .. [14, 18]]
+				}
+				symbol "abc.version.value" {
+					kind: 8
+					location: MyModel.yang [[15, 11] .. [15, 16]]
+					container: "version"
+				}
+				symbol "release" {
+					kind: 2
+					location: MyModel.yang [[17, 11] .. [17, 18]]
+				}
+				symbol "abc.release.value" {
+					kind: 8
+					location: MyModel.yang [[18, 11] .. [18, 16]]
+					container: "release"
+				}
+				symbol "correction" {
+					kind: 2
+					location: MyModel.yang [[20, 11] .. [20, 21]]
+				}
+				symbol "abc.correction.value" {
+					kind: 8
+					location: MyModel.yang [[21, 11] .. [21, 16]]
+					container: "correction"
+				}
+			'''
+		]
+	}
+
 }


### PR DESCRIPTION
So they will show up in the `Outline`.
The name will be the revision date.

Closes: #149.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

----

### For reviewers:

Model:
```
module abc {
    yang-version 1.1;
    namespace abc;
    prefix a;
    revision 2018-10-10 {
          a:version 4;
          a:release 5;
          a:correction 6;
    }
    revision 2018-09-10 {
          a:version 1;
          a:release 2;
          a:correction 3;
    }
    extension version {
        argument value;
    }
    extension release {
        argument value;
    }
    extension correction {
        argument value;
    }
}
```

Before the change:

![screen shot 2018-11-12 at 10 51 17](https://user-images.githubusercontent.com/1405703/48342280-8613c100-e66f-11e8-8b63-ea46cf093243.jpg)

After the change:

![screen shot 2018-11-12 at 13 50 58](https://user-images.githubusercontent.com/1405703/48348652-3ee2fb80-e682-11e8-84ca-b4ab329d6085.jpg)
