### PR TITLE
Consider all context node descriptions for xpath resolution

### DIFF
--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/scoping/xpath/XpathResolver.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/scoping/xpath/XpathResolver.xtend
@@ -84,7 +84,16 @@ class XpathResolver {
 	
 	def XpathType doResolve(XpathExpression expression, QualifiedName contextNode, IScopeContext context) {
 		val element = context.schemaNodeScope.getSingleElement(contextNode)
-		val initialContext = Types.nodeSet(element)
+		val initialContext =
+			if (element === null) {
+				Types.nodeSet(emptyList)
+			} else {
+				val allDescriptions = context.schemaNodeScope.getElements(element.EObjectOrProxy).toList
+				if (allDescriptions.empty)
+					Types.nodeSet(element)
+				else
+					Types.nodeSet(allDescriptions)
+			}
 		internalResolve(expression, initialContext, new Context(context.schemaNodeScope, context.moduleName, initialContext))
 	}
 	

--- a/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/linking/Bug163Test.xtend
+++ b/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/linking/Bug163Test.xtend
@@ -67,4 +67,55 @@ class Bug163Test extends AbstractYangTest {
 		]
 	}
 	
+	@Test 
+	def void testPathLink2() {
+		val r = '''
+			module m1 {
+				prefix c;
+				namespace c;
+			
+			    grouping gy-failure-profile-type {
+			        leaf name {
+			            type string;
+			        }
+			    }
+			    grouping gy-profile-type {
+			        leaf name {
+			            type string;
+			        }
+			        leaf failure-profile {
+			            type leafref {
+			                path "../../gy-failure-profile/name";  
+			            }
+			        }
+			    }
+			
+			    grouping pgw-type {
+			        container credit-control {
+			            list gy-failure-profile {
+			                key "name";
+			                uses gy-failure-profile-type;
+			            }
+			
+			            list gy-profile {
+			                key "name";
+			                uses gy-profile-type;
+			            }
+			        }
+			    }
+			
+			    container epg {
+			        container pgw {
+			            uses pgw-type;
+			        }
+			    }
+			}
+		'''.load()
+		r.assertNoErrors()
+		r.allContents.filter(XpathNameTest).forEach [
+			val exprNode = getContainerOfType(XpathExpression).node
+			assertFalse('''Unresolved reference: «exprNode.text» (line «exprNode.startLine»)''', ref.eIsProxy)
+		]
+	}
+	
 }


### PR DESCRIPTION
Fixes #163 (the second case mentioned in https://github.com/theia-ide/yang-lsp/issues/163#issuecomment-597574695).

From [RFC 7950](https://tools.ietf.org/html/rfc7950#section-7.13):

> The effect of a "uses" reference to a grouping is that the nodes defined by the grouping are copied into the current schema tree...

This requirement was not considered when resolving XPaths: only the local name of the context node was used, but relative paths may refer to the context induced by the `uses` reference.