### PR TITLE
Don't insert noSpace after XPath binary operation

### DIFF
--- a/yang-lsp/io.typefox.yang/model/generated/Yang.ecore
+++ b/yang-lsp/io.typefox.yang/model/generated/Yang.ecore
@@ -218,6 +218,49 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="prefix" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="ref" eType="#//SchemaNode"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="XpathBinaryOperation"/>
+  <eClassifiers xsi:type="ecore:EClass" name="XpathOrOperation" eSuperTypes="#//XpathExpression #//XpathBinaryOperation">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//XpathExpression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//XpathExpression"
+        containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="XpathAndOperation" eSuperTypes="#//XpathExpression #//XpathBinaryOperation">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//XpathExpression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//XpathExpression"
+        containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="XpathEqualityOperation" eSuperTypes="#//XpathExpression #//XpathBinaryOperation">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//XpathExpression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//XpathExpression"
+        containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="XpathRelationalOperation" eSuperTypes="#//XpathExpression #//XpathBinaryOperation">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//XpathExpression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//XpathExpression"
+        containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="XpathAdditiveOperation" eSuperTypes="#//XpathExpression #//XpathBinaryOperation">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//XpathExpression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//XpathExpression"
+        containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="XpathMultiplicativeOperation" eSuperTypes="#//XpathExpression #//XpathBinaryOperation">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//XpathExpression"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//XpathExpression"
+        containment="true"/>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="BinaryOperator" eSuperTypes="#//Expression">
     <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
         containment="true"/>
@@ -247,48 +290,6 @@
   <eClassifiers xsi:type="ecore:EClass" name="Max" eSuperTypes="#//Expression"/>
   <eClassifiers xsi:type="ecore:EClass" name="UnparsedXpath" eSuperTypes="#//XpathExpression">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="text" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-  </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="XpathOrOperation" eSuperTypes="#//XpathExpression">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//XpathExpression"
-        containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//XpathExpression"
-        containment="true"/>
-  </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="XpathAndOperation" eSuperTypes="#//XpathExpression">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//XpathExpression"
-        containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//XpathExpression"
-        containment="true"/>
-  </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="XpathEqualityOperation" eSuperTypes="#//XpathExpression">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//XpathExpression"
-        containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//XpathExpression"
-        containment="true"/>
-  </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="XpathRelationalOperation" eSuperTypes="#//XpathExpression">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//XpathExpression"
-        containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//XpathExpression"
-        containment="true"/>
-  </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="XpathAdditiveOperation" eSuperTypes="#//XpathExpression">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//XpathExpression"
-        containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//XpathExpression"
-        containment="true"/>
-  </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="XpathMultiplicativeOperation" eSuperTypes="#//XpathExpression">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//XpathExpression"
-        containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//XpathExpression"
-        containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="XpathUnaryOperation" eSuperTypes="#//XpathExpression">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>

--- a/yang-lsp/io.typefox.yang/model/generated/Yang.genmodel
+++ b/yang-lsp/io.typefox.yang/model/generated/Yang.genmodel
@@ -208,31 +208,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//XpathNameTest/prefix"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Yang.ecore#//XpathNameTest/ref"/>
     </genClasses>
-    <genClasses ecoreClass="Yang.ecore#//BinaryOperator">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//BinaryOperator/left"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//BinaryOperator/operator"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//BinaryOperator/right"/>
-    </genClasses>
-    <genClasses ecoreClass="Yang.ecore#//FeatureReference">
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Yang.ecore#//FeatureReference/feature"/>
-    </genClasses>
-    <genClasses ecoreClass="Yang.ecore#//UnaryOperation">
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//UnaryOperation/operator"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//UnaryOperation/target"/>
-    </genClasses>
-    <genClasses ecoreClass="Yang.ecore#//BinaryOperation">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//BinaryOperation/left"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//BinaryOperation/operator"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//BinaryOperation/right"/>
-    </genClasses>
-    <genClasses ecoreClass="Yang.ecore#//Literal">
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//Literal/value"/>
-    </genClasses>
-    <genClasses ecoreClass="Yang.ecore#//Min"/>
-    <genClasses ecoreClass="Yang.ecore#//Max"/>
-    <genClasses ecoreClass="Yang.ecore#//UnparsedXpath">
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//UnparsedXpath/text"/>
-    </genClasses>
+    <genClasses ecoreClass="Yang.ecore#//XpathBinaryOperation"/>
     <genClasses ecoreClass="Yang.ecore#//XpathOrOperation">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//XpathOrOperation/left"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//XpathOrOperation/operator"/>
@@ -262,6 +238,31 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//XpathMultiplicativeOperation/left"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//XpathMultiplicativeOperation/operator"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//XpathMultiplicativeOperation/right"/>
+    </genClasses>
+    <genClasses ecoreClass="Yang.ecore#//BinaryOperator">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//BinaryOperator/left"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//BinaryOperator/operator"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//BinaryOperator/right"/>
+    </genClasses>
+    <genClasses ecoreClass="Yang.ecore#//FeatureReference">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Yang.ecore#//FeatureReference/feature"/>
+    </genClasses>
+    <genClasses ecoreClass="Yang.ecore#//UnaryOperation">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//UnaryOperation/operator"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//UnaryOperation/target"/>
+    </genClasses>
+    <genClasses ecoreClass="Yang.ecore#//BinaryOperation">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//BinaryOperation/left"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//BinaryOperation/operator"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//BinaryOperation/right"/>
+    </genClasses>
+    <genClasses ecoreClass="Yang.ecore#//Literal">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//Literal/value"/>
+    </genClasses>
+    <genClasses ecoreClass="Yang.ecore#//Min"/>
+    <genClasses ecoreClass="Yang.ecore#//Max"/>
+    <genClasses ecoreClass="Yang.ecore#//UnparsedXpath">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//UnparsedXpath/text"/>
     </genClasses>
     <genClasses ecoreClass="Yang.ecore#//XpathUnaryOperation">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//XpathUnaryOperation/operator"/>

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/Yang.xtext
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/Yang.xtext
@@ -16,7 +16,7 @@ fragment StatementEnd returns Statement:
 ;
 
 Statement:
-	  SchemaNode | 
+	  SchemaNode |
 	  OtherStatement
 ;
 
@@ -507,7 +507,7 @@ GroupingRef:
 
 XpathExpression returns XpathExpression:
 	{ UnparsedXpath } '<<<<' text=STRING '>>>>'
-	| ParsedXpathExpression; 
+	| ParsedXpathExpression;
 
 ParsedXpathExpression returns XpathExpression:  
 	XpathOrExpr
@@ -608,8 +608,33 @@ XpathAxisName:
 ;
 
 XpathIDOrKw :
-	ID | 'div' | 'and'| 'or' | 'mod' | XpathAxisName | XpathNodeType | '*'
+	ID | 'div' | 'and' | 'or' | 'mod' | XpathAxisName | XpathNodeType | '*'
 ;
+
+
+// Dummy rules for type hierarchy
+
+XpathBinaryOperation:
+	XpathOrOperation | XpathAndOperation | XpathEqualityOperation | XpathRelationalOperation | XpathAdditiveOperation | XpathMultiplicativeOperation;
+
+XpathOrOperation:
+	left=XpathExpression '#dummy#' operator='or' right=XpathExpression;
+
+XpathAndOperation:
+	left=XpathExpression '#dummy#' operator='and' right=XpathExpression;
+
+XpathEqualityOperation:
+	left=XpathExpression '#dummy#' operator=('='|'!=') right=XpathExpression;
+
+XpathRelationalOperation:
+	left=XpathExpression '#dummy#' operator=('<'|'>'|'<='|'>=') right=XpathExpression;
+
+XpathAdditiveOperation:
+	left=XpathExpression '#dummy#' operator=('+'|'-') right=XpathExpression;
+
+XpathMultiplicativeOperation:
+	left=XpathExpression '#dummy#' operator=('*'|'div'|'mod') right=XpathExpression;
+
 
 /////////////////////////////////
 /////////////////////////////////

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/formatting2/YangFormatter.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/formatting2/YangFormatter.xtend
@@ -71,6 +71,7 @@ import io.typefox.yang.yang.Unknown
 import io.typefox.yang.yang.Uses
 import io.typefox.yang.yang.Value
 import io.typefox.yang.yang.When
+import io.typefox.yang.yang.XpathBinaryOperation
 import io.typefox.yang.yang.XpathExpression
 import io.typefox.yang.yang.XpathLocation
 import io.typefox.yang.yang.XpathNameTest
@@ -539,16 +540,25 @@ class YangFormatter extends AbstractFormatter2 {
     protected def formatXpath(extension IFormattableDocument document, XpathExpression expression) {
         val nodeRegions = expression.allSemanticRegions.toList
         nodeRegions.head.prepend[oneSpace]
-        nodeRegions
-        	.tail
-        	.filter[grammarElement == HIDDENRule && (semanticElement instanceof XpathLocation || semanticElement instanceof XpathNameTest)]
-        	.forEach[prepend[noSpace]]
+        nodeRegions.tail.forEach[formatXpathRegion(document)]
         val nextSemanticRegion = nodeRegions.last.nextSemanticRegion
         if (HIDDENRule == nextSemanticRegion.grammarElement) {
             nextSemanticRegion.prepend[noSpace].append[oneSpace]
         } else {
             nodeRegions.last.append[oneSpace]
         }
+    }
+    
+    private def formatXpathRegion(ISemanticRegion region, extension IFormattableDocument document) {
+    	if (region.grammarElement == HIDDENRule) {
+    		val semantic = region.semanticElement
+    		if (semantic instanceof XpathLocation || semantic instanceof XpathNameTest) {
+    			val previousSemantic = region.previousSemanticRegion.semanticElement
+    			if (!(previousSemantic instanceof XpathBinaryOperation)) {
+    				region.prepend[noSpace]
+				}
+			}
+    	}
     }
     
     protected def formatRefinement(extension IFormattableDocument document, Expression expression) {


### PR DESCRIPTION
Fixes #166.

I added a new EClass `XpathBinaryOperation` so I can easily check whether an `XpathExpression` is a binary operation.