### PR TITLE
Serialize asterisk if it was parsed as such

### DIFF
--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/resource/YangCrossReferenceSerializer.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/resource/YangCrossReferenceSerializer.xtend
@@ -1,6 +1,7 @@
 package io.typefox.yang.resource
 
 import com.google.inject.Inject
+import io.typefox.yang.scoping.xpath.XpathResolver
 import io.typefox.yang.utils.YangExtensions
 import io.typefox.yang.yang.AbstractImport
 import io.typefox.yang.yang.CurrentRef
@@ -23,6 +24,8 @@ import org.eclipse.xtext.scoping.IScopeProvider
 import org.eclipse.xtext.serializer.diagnostic.ISerializationDiagnostic.Acceptor
 import org.eclipse.xtext.serializer.tokens.CrossReferenceSerializer
 import org.eclipse.xtext.serializer.tokens.SerializerScopeProviderBinding
+
+import static io.typefox.yang.yang.YangPackage.Literals.*
 
 import static extension org.eclipse.xtext.EcoreUtil2.*
 
@@ -67,6 +70,9 @@ class YangCrossReferenceSerializer extends CrossReferenceSerializer {
 		if (resolvedTarget !== null && node !== null) {
 			val text = linkingHelper.getCrossRefNodeAsString(node, true)
 			val qn = qualifiedNameConverter.toQualifiedName(text)
+			if (ref == XPATH_NAME_TEST__REF && qn == XpathResolver.ASTERISK) {
+				return text
+			}
 			val targetURI = EcoreUtil2.getPlatformResourceOrNormalizedURI(resolvedTarget)
 			for (desc : scope.getElements(qn)) {
 				if (targetURI == desc.EObjectURI)

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/scoping/Linker.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/scoping/Linker.xtend
@@ -21,7 +21,7 @@ class Linker {
 	@Inject LazyURIEncoder lazyURIEncoder
 	@Inject IQualifiedNameConverter qualifiedNameConverter
 
-	public static IEObjectDescription ROOT = new EObjectDescription(QualifiedName.EMPTY, null, null);
+	public static final IEObjectDescription ROOT = new EObjectDescription(QualifiedName.EMPTY, null, null)
 
 	def <T> T link(EObject element, EReference reference, (QualifiedName)=>IEObjectDescription resolver) {
 		val proxy = element.eGet(reference, false) as EObject

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/scoping/ScopeContextProvider.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/scoping/ScopeContextProvider.xtend
@@ -198,8 +198,7 @@ class ScopeContextProvider {
 		}
 		val pref = identifier.internalGetQualifiedName(prefix, context)
 		linker.link(identifier, YangPackage.Literals.SCHEMA_NODE_IDENTIFIER__SCHEMA_NODE) [
-			val result = context.schemaNodeScope.getSingleElement(pref)
-			return result
+			context.schemaNodeScope.getSingleElement(pref)
 		]
 		return pref
 	}

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/scoping/xpath/XpathResolver.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/scoping/xpath/XpathResolver.xtend
@@ -59,7 +59,7 @@ class XpathResolver {
 	@Inject ScopeContextProvider scopeContextProvider
 	@Inject extension YangExtensions 
 	
-	static val ASTERISK = QualifiedName.create('*')
+	public static val ASTERISK = QualifiedName.create('*')
 	
 	@Data static class Context {
 		MapScope nodeScope
@@ -293,8 +293,8 @@ class XpathResolver {
 			if (contextType instanceof NodeSetType) {
 				if (!(e.node instanceof XpathNodeType)) {
 					val ref = new AtomicReference<XpathType>()
-					linker.link(e.node, YangPackage.Literals.XPATH_NAME_TEST__REF) [
-						if (it.lastSegment == '*') {
+					linker.link(e.node, YangPackage.Literals.XPATH_NAME_TEST__REF) [ nodeName |
+						if (nodeName.endsWith(ASTERISK)) {
 							ref.set(contextType)
 							return contextType.EObjectDescription
 						} else {

--- a/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/serializer/SerializationTest.xtend
+++ b/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/serializer/SerializationTest.xtend
@@ -90,6 +90,54 @@ class SerializationTest extends AbstractYangTest {
 	}
 	
 	@Test
+	def void testIssue160() {
+		val resource = load('''
+			module xpath-asterisk {
+			  namespace xa;
+			  prefix xa;
+			  container routings {
+			    list routing {
+			    	key "name";
+			        leaf name {
+			            type string;
+			        }
+			        list api {
+			       	  key "name";
+			          leaf name {
+			       	    type string;
+			       	    must "count(/xa:routings/xa:routing[*]/xa:api[xa:name = current()]) = 1";
+			          }
+			       }
+			    }
+			  }
+			}
+		''') as XtextResource
+		
+		val serialized = resource.serializer.serialize(resource.contents.head)
+		assertEquals('''
+			module xpath-asterisk {
+			  namespace xa;
+			  prefix xa;
+			  container routings {
+			    list routing {
+			    	key "name";
+			        leaf name {
+			            type string;
+			        }
+			        list api {
+			       	  key "name";
+			          leaf name {
+			       	    type string;
+			       	    must "count(/xa:routings/xa:routing[*]/xa:api[xa:name = current()]) = 1";
+			          }
+			       }
+			    }
+			  }
+			}
+			'''.toString, serialized)
+	}
+	
+	@Test
 	def void testIssue164a() {
 		val resource = load('''
 			module serialize-test {


### PR DESCRIPTION
See #160. In case an XPath step was parsed as `*`, the serializer should use the same form instead of resolving a specific node.