### PR TITLE
Format no space around refinement operators unless they are in quotes

### DIFF
--- a/yang-lsp/io.typefox.yang/model/generated/Yang.ecore
+++ b/yang-lsp/io.typefox.yang/model/generated/Yang.ecore
@@ -261,7 +261,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//XpathExpression"
         containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="BinaryOperator" eSuperTypes="#//Expression">
+  <eClassifiers xsi:type="ecore:EClass" name="BinaryOperation" eSuperTypes="#//Expression">
     <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
         containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
@@ -274,13 +274,6 @@
   <eClassifiers xsi:type="ecore:EClass" name="UnaryOperation" eSuperTypes="#//Expression">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="target" eType="#//Expression"
-        containment="true"/>
-  </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="BinaryOperation" eSuperTypes="#//Expression">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//Expression"
-        containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="operator" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="right" eType="#//Expression"
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Literal" eSuperTypes="#//Expression">

--- a/yang-lsp/io.typefox.yang/model/generated/Yang.genmodel
+++ b/yang-lsp/io.typefox.yang/model/generated/Yang.genmodel
@@ -239,10 +239,10 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//XpathMultiplicativeOperation/operator"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//XpathMultiplicativeOperation/right"/>
     </genClasses>
-    <genClasses ecoreClass="Yang.ecore#//BinaryOperator">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//BinaryOperator/left"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//BinaryOperator/operator"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//BinaryOperator/right"/>
+    <genClasses ecoreClass="Yang.ecore#//BinaryOperation">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//BinaryOperation/left"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//BinaryOperation/operator"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//BinaryOperation/right"/>
     </genClasses>
     <genClasses ecoreClass="Yang.ecore#//FeatureReference">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Yang.ecore#//FeatureReference/feature"/>
@@ -250,11 +250,6 @@
     <genClasses ecoreClass="Yang.ecore#//UnaryOperation">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//UnaryOperation/operator"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//UnaryOperation/target"/>
-    </genClasses>
-    <genClasses ecoreClass="Yang.ecore#//BinaryOperation">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//BinaryOperation/left"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//BinaryOperation/operator"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Yang.ecore#//BinaryOperation/right"/>
     </genClasses>
     <genClasses ecoreClass="Yang.ecore#//Literal">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Yang.ecore#//Literal/value"/>

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/Yang.xtext
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/Yang.xtext
@@ -361,11 +361,11 @@ IfFeature:
 ;
 
 IfFeatureOrExpression returns Expression:
-	IfFeatureAndExpression ({BinaryOperator.left=current} operator='or' right=IfFeatureAndExpression)*
+	IfFeatureAndExpression ({BinaryOperation.left=current} operator='or' right=IfFeatureAndExpression)*
 ;
 
 IfFeatureAndExpression returns Expression:
-	IfFeatureExpression ({BinaryOperator.left=current} operator='and' right=IfFeatureExpression)*
+	IfFeatureExpression ({BinaryOperation.left=current} operator='and' right=IfFeatureExpression)*
 ;
 
 IfFeatureExpression returns Expression:

--- a/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/formatter/Bug151Test.xtend
+++ b/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/formatter/Bug151Test.xtend
@@ -1,0 +1,100 @@
+package io.typefox.yang.tests.formatter
+
+import io.typefox.yang.tests.AbstractYangTest
+import io.typefox.yang.yang.Container
+import io.typefox.yang.yang.Leaf
+import io.typefox.yang.yang.Module
+import io.typefox.yang.yang.Type
+import io.typefox.yang.yang.YangFactory
+import org.eclipse.xtext.resource.XtextResource
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+class Bug151Test extends AbstractYangTest {
+	
+	@Test
+	def void testBinaryOp1() {
+		assertFormatted[
+			expectation = '''
+				module ma {
+				    yang-version 1.1;
+				    prefix ma;
+				    description "Test";
+				    container c1 {
+				        leaf l1 {
+				            type string {
+				                length 1..255;
+				            }
+				        }
+				    }
+				}
+			'''
+			toBeFormatted = '''
+				module ma {
+					yang-version 1.1;
+					prefix ma;
+					description "Test";
+				    container c1 {
+				         leaf l1 {
+				             type string {
+				                 length 1..255;
+				             }
+				         }
+				    }
+				}
+			'''
+			useNodeModel = false
+		]
+	}
+	
+	@Test
+	def void testBinaryOp2() {
+		val resource = '''
+			module ma {
+				yang-version 1.1;
+				prefix ma;
+				description "Test";
+			    container c1 {
+			        leaf l1 {
+			            type string;
+			        }
+			    }
+			}
+		'''.load() as XtextResource
+
+		val module = resource.contents.head as Module
+		val c1 = module.substatements.filter(Container).findFirst[name == 'c1']
+		val l1 = c1.substatements.filter(Leaf).findFirst[name == 'l1']
+		val strType = l1.substatements.filter(Type).head
+		val factory = YangFactory.eINSTANCE
+		val start = factory.createLiteral()
+		start.value = '1'
+		val end = factory.createLiteral()
+		end.value = '255'
+		val bopt = factory.createBinaryOperation()
+		bopt.operator = '..'
+		bopt.left = start
+		bopt.right = end
+		val length = factory.createLength()
+		length.expression = bopt
+		strType.substatements.add(length)
+		
+		val serialized = resource.serializer.serialize(module)
+		assertEquals('''
+			module ma {
+				yang-version 1.1;
+				prefix ma;
+				description "Test";
+			    container c1 {
+			        leaf l1 {
+			            type string {
+			                length 1..255;
+			            }
+			        }
+			    }
+			}
+		'''.toString, serialized)
+	}
+	
+}


### PR DESCRIPTION
Fixes #151. I removed the EClass `BinaryOperator` and reused `BinaryOperation` instead for consistency.