### PR TITLE
[grammar] allow lexical operators as namespaces

### DIFF
--- a/yang-lsp/io.typefox.yang.ide/yang.settings
+++ b/yang-lsp/io.typefox.yang.ide/yang.settings
@@ -1,3 +1,3 @@
 {
-	"excludePath": "build:bin" 
+	"excludePath": "bin:build" 
 }

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/Yang.xtext
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/Yang.xtext
@@ -658,7 +658,7 @@ IdOrKw :
 ;
 
 QualifiedTypeName:
-	((ID | KEYWORD) ':')? (ID|KEYWORD)
+	((ID | KEYWORD | LEXICAL_OPERATOR) ':')? (ID|KEYWORD)
 ;
 
 BUILTIN_TYPE :
@@ -691,6 +691,7 @@ KEYWORD :
 	| 'delete'
 	| 'deprecated'
 	| 'false'
+	| 'or'
 	| 'max'
 	| 'min'
 	| 'not-supported'
@@ -780,7 +781,8 @@ terminal ID       : 'an id';
 terminal EXTENSION_NAME : 'ID:ID // only valid on statement ctx';
 terminal STRING   : 'an unquoted string';
 terminal NUMBER   : 'positive integer value';
-terminal OPERATOR : 'and' | 'or' | 'mod' | 'div' | '*' | '/' | '//' | '|' | '+' | '-' | '=' | '!=' | '<' | '<=' | '>' | '>=';
+terminal SYMBOLIC_OPERATOR : '*' | '/' | '//' | '|' | '+' | '-' | '=' | '!=' | '<' | '<=' | '>' | '>=';
+terminal LEXICAL_OPERATOR : 'a lexical operator'; //'and' | 'or' | 'mod' | 'div';
 
 terminal ML_COMMENT	: '/*' -> '*/';
 terminal SL_COMMENT 	: '//' !('\n'|'\r')* ('\r'? '\n')?;

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/parser/antlr/lexer/jflex/YangFlexer.flex
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/parser/antlr/lexer/jflex/YangFlexer.flex
@@ -88,7 +88,9 @@ ESCAPED_DQ_STRING= \\\" [^\\\"]* \\\"?
 NUMBER= ("+"|"-")? {U_NUMBER}
 U_NUMBER= [0-9]+ ("." [0-9]+)? | "." [0-9]+
 
-OPERATOR= "and" | "or" | "mod" | "div" | "*" | "|" | "+" | "-" | "=" | "!=" | "<" | "<=" | ">" | ">="
+SYMBOLIC_OPERATOR= "*" | "|" | "+" | "-" | "=" | "!=" | "<" | "<=" | ">" | ">="
+
+LEXICAL_OPERATOR= "and" | "or" | "mod" | "div"
 
 STRING_CONCAT= ({WS} | {ML_COMMENT} | {SL_COMMENT})* "+" ({WS} | {ML_COMMENT} | {SL_COMMENT})*
 
@@ -123,7 +125,8 @@ STRING_CONCAT= ({WS} | {ML_COMMENT} | {SL_COMMENT})* "+" ({WS} | {ML_COMMENT} | 
 	{SL_COMMENT} { return RULE_SL_COMMENT; }
 	\"          {yybegin(IN_EXPRESSION_STRING); return RULE_HIDDEN;}
 	"'"         {yybegin(IN_SQ_EXPRESSION_STRING); return RULE_HIDDEN;}
-	{OPERATOR}  { return RULE_OPERATOR; }
+	{SYMBOLIC_OPERATOR}  { return RULE_SYMBOLIC_OPERATOR; }
+	{LEXICAL_OPERATOR}  { return RULE_LEXICAL_OPERATOR; }
 	"binary"                {return Binary;}
 	"bits"                  {return Bits;}
 	"boolean"               {return Boolean;}
@@ -161,7 +164,8 @@ STRING_CONCAT= ({WS} | {ML_COMMENT} | {SL_COMMENT})* "+" ({WS} | {ML_COMMENT} | 
 <IN_EXPRESSION_STRING> {
 	{SINGLE_QUOTED_STRING} { return RULE_STRING; }
 	{ESCAPED_DQ_STRING}    { return RULE_STRING; }
-	{OPERATOR}  { return RULE_OPERATOR; }
+	{SYMBOLIC_OPERATOR}  { return RULE_SYMBOLIC_OPERATOR; }
+	{LEXICAL_OPERATOR}  { return RULE_LEXICAL_OPERATOR; }
 	"binary"                {return Binary;}
 	"bits"                  {return Bits;}
 	"boolean"               {return Boolean;}
@@ -201,7 +205,8 @@ STRING_CONCAT= ({WS} | {ML_COMMENT} | {SL_COMMENT})* "+" ({WS} | {ML_COMMENT} | 
 
 <IN_SQ_EXPRESSION_STRING> {
 	{DOUBLE_QUOTED_STRING}    { return RULE_STRING; }
-	{OPERATOR}  { return RULE_OPERATOR; }
+	{SYMBOLIC_OPERATOR}  { return RULE_SYMBOLIC_OPERATOR; }
+	{LEXICAL_OPERATOR}  { return RULE_LEXICAL_OPERATOR; }
 	"binary"                {return Binary;}
 	"bits"                  {return Bits;}
 	"boolean"               {return Boolean;}

--- a/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/YangParsingTest.xtend
+++ b/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/YangParsingTest.xtend
@@ -326,6 +326,14 @@ class YangParsingTest {
 		}'''.wrapModule.assertNoParserErrors;
 	}
 
+	@Test
+	def void testGH193() {
+		'''
+		typedef foo1 {
+		  type or:origin-ref;
+		}'''.wrapModule.assertNoParserErrors;
+	}
+
 	private def wrapModule(CharSequence it) '''
 		module foo {
 			«it»


### PR DESCRIPTION
Fixes #193

Signed-off-by: Jan Koehnlein <jan.koehnlein@typefox.io>