### PR TITLE
Submodule's belongs-to reference finds wrong main module #195

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,3 +20,8 @@ jobs:
     - name: Run Gradle Build and Tests
       run: ./gradlew --no-daemon build
       working-directory: yang-lsp
+    - name: Publish Unit Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v1
+      if: always()
+      with:
+        files: yang-lsp/**/test-results/**/*.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - dh-moduleRef-siblings-195
+      - master
   pull_request:
     branches:
-      - dh-moduleRef-siblings-195
+      - master
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - dh-moduleRef-siblings-195
+  pull_request:
+    branches:
+      - dh-moduleRef-siblings-195
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - uses: actions/checkout@v2
+    - name: Run Gradle Build and Tests
+      run: ./gradlew --no-daemon build
+      working-directory: yang-lsp

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/scoping/Linker.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/scoping/Linker.xtend
@@ -34,7 +34,7 @@ class Linker {
 				LinkingErrorMessageProvider.markOK(element)
 			} else if (candidate !== null) {
 				val resolved = EcoreUtil.resolve(candidate.getEObjectOrProxy, element)
-				element.eSet(reference, resolved)
+				element.eSet(reference, resolved) // replace SchemaNode with linked value (e.g. Leaf, List)
 				return resolved as T
 			}
 		}

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/scoping/ScopeContextProvider.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/scoping/ScopeContextProvider.xtend
@@ -161,7 +161,16 @@ class ScopeContextProvider {
 			return null
 		}
 		return linker.<Module>link(belongsTo, BELONGS_TO__MODULE) [ name |
-			moduleScope.getSingleElement(name)
+			val candidates = moduleScope.getElements(name)
+			val matches = newArrayList
+			for (candidate : candidates) {
+				matches.add(candidate)
+			}
+			val filtered = filterUnrelatedModules(submodule.eResource, matches)
+			if (filtered.size > 0) {
+				return filtered.head
+			}
+			return matches.head // take first
 		]
 	}
 	
@@ -577,6 +586,12 @@ class ScopeContextProvider {
 			val dir = candidate.EObjectURI.directory
 			!resourceDir.startsWith(dir) && !dir.startsWith(resourceDir)
 		]
+		if(result.size > 1) {
+			result.removeIf [ candidate |
+				val dir = candidate.EObjectURI.directory
+				resourceDir != dir
+			]
+		}
 		if (result.empty)
 			return candidates
 		else

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/scoping/ScopeContextProvider.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/scoping/ScopeContextProvider.xtend
@@ -222,7 +222,13 @@ class ScopeContextProvider {
 		}
 		val qn = identifier.internalGetQualifiedName(nodePath, context)
 		linker.link(identifier, YangPackage.Literals.SCHEMA_NODE_IDENTIFIER__SCHEMA_NODE) [
-			context.schemaNodeScope.getSingleElement(qn)
+			val element = context.schemaNodeScope.getSingleElement(qn)
+			if(element !== null) {
+				return element
+			}
+			// try sub-module scope.
+			// When sub module is loaded before super module, SchemaNodes might not be propagated properly
+			context.moduleBelongingSubModules.map[subCtx | subCtx.schemaNodeScope.getSingleElement(qn)].filterNull.head
 		]
 		return qn
 	}

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/validation/YangValidator.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/validation/YangValidator.xtend
@@ -481,7 +481,7 @@ class YangValidator extends AbstractYangValidator {
 		// (4) If the target node is a choice node, the "case" statement or a
 		// shorthand "case" statement (see Section 7.9.2) can be used within the "augment" statement.
 		val target = path?.schemaNode;
-		if (target !== null) {
+		if (target !== null && !target.eIsProxy) {
 			val validSubstatements = validAugmentStatements.get(target.eClass);
 			if (validSubstatements.nullOrEmpty) {
 				// Implicit `input` and `output` is added to all "rpc" and "action" statements. (See: RFC 7950 7.14)

--- a/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/linking/Bug200Test.xtend
+++ b/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/linking/Bug200Test.xtend
@@ -52,7 +52,7 @@ class Bug200Test extends AbstractYangTest {
 
 	@Test
 	def void testBelongsToIncludeLinking_01() {
-		// path doen't matter but better for debugging
+		// path doesn't matter but better for debugging
 		val superRes = augment_super.load('super')
 		val sub1Res = augment_sub1.load('sub1')
 		val sub0Res = augment_sub0.load('sub0')
@@ -68,8 +68,7 @@ class Bug200Test extends AbstractYangTest {
 
 	@Test
 	def void testBelongsToIncludeLinking_02() {
-		println('''''')
-		// path doen't matter but better for debugging
+		// path doesn't matter but better for debugging
 		val sub0Res = augment_sub0.load('sub0')
 		val superRes = augment_super.load('super')
 		val sub1Res = augment_sub1.load('sub1')
@@ -82,7 +81,7 @@ class Bug200Test extends AbstractYangTest {
 	@Test
 	def void testBelongsToIncludeLinking_03() {
 		println('''''')
-		// path doen't matter but better for debugging
+		// path doesn't matter but better for debugging
 		val sub1Res = augment_sub1.load('sub1')
 		val superRes = augment_super.load('super')
 		val sub0Res = augment_sub0.load('sub0')

--- a/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/linking/Bug200Test.xtend
+++ b/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/linking/Bug200Test.xtend
@@ -1,0 +1,95 @@
+package io.typefox.yang.tests.linking
+
+import io.typefox.yang.tests.AbstractYangTest
+import io.typefox.yang.yang.Augment
+import io.typefox.yang.yang.List
+import org.junit.Test
+
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertEquals
+
+class Bug200Test extends AbstractYangTest {
+	val augment_super = '''
+		module augment-super {
+		   namespace "urn:test";
+		   prefix "as";
+		   
+		   include augment-sub0;
+		   include augment-sub1;
+		        
+		   augment "/interfaces/ifEntry" {
+		   } 
+		 }
+		
+		
+	'''
+
+	val augment_sub1 = '''
+		submodule augment-sub1 {
+		  belongs-to augment-super {
+		    prefix "as";
+		  }
+		
+		  include augment-sub0;
+		
+		  augment "/interfaces" {
+		    list ifEntry {
+		    }
+		  }
+		} 
+	'''
+	val augment_sub0 = '''
+		submodule augment-sub0 {
+		  belongs-to augment-super {
+		    prefix "as";
+		  }
+		  
+		  container interfaces;
+		
+		} 
+	'''
+
+	@Test
+	def void testBelongsToIncludeLinking_01() {
+		// path doen't matter but better for debugging
+		val superRes = augment_super.load('super')
+		val sub1Res = augment_sub1.load('sub1')
+		val sub0Res = augment_sub0.load('sub0')
+		val superModule = superRes.root // fully resolve
+		superRes.assertNoErrors;
+		sub1Res.assertNoErrors;
+		sub0Res.assertNoErrors;
+		val schemaNode = superModule.substatements.filter(Augment)?.head?.path?.schemaNode
+		assertNotNull('Augment with schema node not found in augment_super', schemaNode)
+		assertTrue('Schemanode must be a List', schemaNode instanceof List)
+		assertEquals((schemaNode as List).name, "ifEntry")
+	}
+
+	@Test
+	def void testBelongsToIncludeLinking_02() {
+		println('''''')
+		// path doen't matter but better for debugging
+		val sub0Res = augment_sub0.load('sub0')
+		val superRes = augment_super.load('super')
+		val sub1Res = augment_sub1.load('sub1')
+		sub0Res.root // fully resolve
+		superRes.assertNoErrors;
+		sub1Res.assertNoErrors;
+		sub0Res.assertNoErrors;
+	}
+
+	@Test
+	def void testBelongsToIncludeLinking_03() {
+		println('''''')
+		// path doen't matter but better for debugging
+		val sub1Res = augment_sub1.load('sub1')
+		val superRes = augment_super.load('super')
+		val sub0Res = augment_sub0.load('sub0')
+		sub1Res.root // fully resolve
+		superRes.assertNoErrors;
+		sub1Res.assertNoErrors;
+		sub0Res.assertNoErrors;
+	}
+
+}

--- a/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/linking/ModuleLinkingTest.xtend
+++ b/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/linking/ModuleLinkingTest.xtend
@@ -445,5 +445,76 @@ class ModuleLinkingTest extends AbstractYangTest {
 		assertEquals(foo.root.name, bar.allContents.filter(Import).head.module.name)
 	}
 	
+	/**
+	 * Issue: #195
+	 */
+	@Test def void testLinkToSiblingsAndChildrenFirst_01() {
+		val foo1 = load('''
+			module simple1 {
+			    yang-version 1.1;
+			    namespace urn:rdns:simple1;
+			    prefix simple1e;
+			    include subx;
+			   
+			    revision 2021-02-22;
+			    
+			    container simple1 {
+			    }
+			}
+		''', '/dir1')
+		val foo2 = load('''
+			module simple1 {
+			    yang-version 1.1;
+			    namespace urn:rdns:simple1;
+			    prefix simple1e;
+			    include subx;
+			   
+			    revision 2021-02-22;
+			    
+			    container simple1 {
+			    }
+			}
+		''', '/dir2')
+		
+		val sub1 = load('''
+			submodule subx {
+			    yang-version 1.1;
+			    belongs-to simple1 {
+			        prefix simple1e;
+			    }
+			    revision 2021-02-22;
+			
+			    container subc {
+			        leaf x {
+			            type string;
+			        }
+			    }
+			}
+		''', '/dir1')
+		val sub2 = load('''
+			submodule subx {
+			    yang-version 1.1;
+			    belongs-to simple1 {
+			        prefix simple1e;
+			    }
+			    revision 2021-02-22;
+			
+			    container subc {
+			        leaf x {
+			            type string;
+			        }
+			    }
+			}
+		''', '/dir2')
+		validator.validate(foo1)
+		assertNoIssues(foo1.root)
+		validator.validate(foo2)
+		assertNoIssues(foo2.root)
+		validator.validate(sub1)
+		assertNoIssues(sub1.root)
+		validator.validate(sub2)
+		assertNoIssues(sub2.root)
+	}
+	
 	
 }


### PR DESCRIPTION
Scoping: consider sibling first when multiple candidates are available