### PR TITLE
XpathExpr doesn't accept non token-boundaries concatenated String

### DIFF
--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/YangRuntimeModule.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/YangRuntimeModule.xtend
@@ -7,6 +7,8 @@ import com.google.inject.Binder
 import io.typefox.yang.documentation.DocumentationProvider
 import io.typefox.yang.formatting2.YangIndentationInformation
 import io.typefox.yang.formatting2.YangTextRegionAccessBuilder
+import io.typefox.yang.parser.antlr.lexer.jflex.JFlexBasedInternalYangLexer
+import io.typefox.yang.parser.antlr.lexer.jflex.JFlexBasedYangLexerWithLookahead
 import io.typefox.yang.resource.YangCrossReferenceSerializer
 import io.typefox.yang.resource.YangResource
 import io.typefox.yang.resource.YangSerializer
@@ -124,4 +126,7 @@ class YangRuntimeModule extends AbstractYangRuntimeModule {
 		YangTokenUtil
 	}
 	
+	def Class<? extends JFlexBasedInternalYangLexer> bindJFlexBasedInternalYangLexer() {
+		return JFlexBasedYangLexerWithLookahead
+	}
 }

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/parser/antlr/lexer/jflex/JFlexBasedYangLexerWithLookahead.java
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/parser/antlr/lexer/jflex/JFlexBasedYangLexerWithLookahead.java
@@ -55,6 +55,7 @@ public class JFlexBasedYangLexerWithLookahead extends JFlexBasedInternalYangLexe
 
 	/**
 	 * 
+	 * @return <code>true</code> in case [ID][HIDDEN][HIDDEN][ID]
 	 */
 	private boolean canSquash(Token currentToken, Token lookAheadToken, Token lookAheadToken2,
 			Token currentSuperToken) {

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/parser/antlr/lexer/jflex/JFlexBasedYangLexerWithLookahead.java
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/parser/antlr/lexer/jflex/JFlexBasedYangLexerWithLookahead.java
@@ -1,0 +1,85 @@
+package io.typefox.yang.parser.antlr.lexer.jflex;
+
+import org.antlr.runtime.ANTLRStringStream;
+import org.antlr.runtime.CommonToken;
+import org.antlr.runtime.Lexer;
+import org.antlr.runtime.Token;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+import io.typefox.yang.parser.antlr.lexer.jflex.YangFlexer.CommonTokenWithText;
+
+public class JFlexBasedYangLexerWithLookahead extends JFlexBasedInternalYangLexer {
+
+	private Token currentToken;
+	private Token lookAheadToken;
+	private Token lookAheadToken2;
+
+	@Inject
+	Provider<JFlexBasedInternalYangLexer> prober;
+
+	@Override
+	public Token nextToken() {
+//		if(true)
+//			return super.nextToken();
+		Token currentSuperToken = super.nextToken();
+
+		if (currentToken == null) {
+			// start: [curr][next][next]
+			currentToken = currentSuperToken;
+			lookAheadToken = super.nextToken();
+			lookAheadToken2 = super.nextToken();
+			currentSuperToken = super.nextToken();
+		}
+
+		while (canSquash(currentToken, lookAheadToken, lookAheadToken2, currentSuperToken)) {
+			// do squash
+			Token squashed = squash(currentToken, lookAheadToken, lookAheadToken2, currentSuperToken);
+			currentToken = squashed;
+			lookAheadToken = super.nextToken();
+			lookAheadToken2 = super.nextToken();
+			currentSuperToken = super.nextToken();
+		}
+		Token result = currentToken;
+		// push left: [curr][la1][la2] -> [la1][la2][next]
+		currentToken = lookAheadToken;
+		lookAheadToken = lookAheadToken2;
+		lookAheadToken2 = currentSuperToken;
+		return result;
+	}
+
+	@Override
+	public void reset() {
+		super.reset();
+		currentToken = lookAheadToken = lookAheadToken2 = null;
+	}
+
+	/**
+	 * 
+	 * @return <code>true</code> in case [ID][HIDDEN][HIDDEN][ID]
+	 */
+	private boolean canSquash(Token currentToken, Token lookAheadToken, Token lookAheadToken2,
+			Token currentSuperToken) {
+		if (currentToken.getType() == RULE_ID && lookAheadToken.getType() == RULE_HIDDEN
+				&& lookAheadToken2.getType() == RULE_HIDDEN && currentSuperToken.getType() == RULE_ID) {
+			Lexer lexer = prober.get();
+			lexer.setCharStream(new ANTLRStringStream(currentToken.getText() + currentSuperToken.getText()));
+			return lexer.nextToken().getType() == RULE_ID && lexer.nextToken().getType() == EOF;
+		}
+		return false;
+	}
+
+	/**
+	 * 
+	 * @return for case [ID][HIDDEN][HIDDEN][ID] -> [ID+ID]
+	 */
+	private Token squash(Token currentToken, Token lookAheadToken, Token lookAheadToken2, Token currentSuperToken) {
+		CommonToken lookAheadCommonToken = (CommonToken) lookAheadToken;
+		CommonToken squashed = new CommonTokenWithText(currentToken.getText() + currentSuperToken.getText(),
+				currentSuperToken.getType(), lookAheadCommonToken.getChannel(),
+				((CommonToken) currentToken).getStartIndex());
+		System.out.println("JFlexBasedYangLexerWithLookahead.squash(): to " + squashed.getText());
+		return squashed;
+	}
+}

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/parser/antlr/lexer/jflex/JFlexBasedYangLexerWithLookahead.java
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/parser/antlr/lexer/jflex/JFlexBasedYangLexerWithLookahead.java
@@ -21,8 +21,6 @@ public class JFlexBasedYangLexerWithLookahead extends JFlexBasedInternalYangLexe
 
 	@Override
 	public Token nextToken() {
-//		if(true)
-//			return super.nextToken();
 		Token currentSuperToken = super.nextToken();
 
 		if (currentToken == null) {
@@ -57,7 +55,6 @@ public class JFlexBasedYangLexerWithLookahead extends JFlexBasedInternalYangLexe
 
 	/**
 	 * 
-	 * @return <code>true</code> in case [ID][HIDDEN][HIDDEN][ID]
 	 */
 	private boolean canSquash(Token currentToken, Token lookAheadToken, Token lookAheadToken2,
 			Token currentSuperToken) {
@@ -78,8 +75,7 @@ public class JFlexBasedYangLexerWithLookahead extends JFlexBasedInternalYangLexe
 		CommonToken lookAheadCommonToken = (CommonToken) lookAheadToken;
 		CommonToken squashed = new CommonTokenWithText(currentToken.getText() + currentSuperToken.getText(),
 				currentSuperToken.getType(), lookAheadCommonToken.getChannel(),
-				((CommonToken) currentToken).getStartIndex());
-		System.out.println("JFlexBasedYangLexerWithLookahead.squash(): to " + squashed.getText());
+				((CommonToken) currentToken).getStartIndex(), ((CommonToken) currentSuperToken).getStopIndex());
 		return squashed;
 	}
 }

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/parser/antlr/lexer/jflex/YangFlexer.flex
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/parser/antlr/lexer/jflex/YangFlexer.flex
@@ -54,7 +54,11 @@ import static io.typefox.yang.parser.antlr.internal.InternalYangParser.*;
 		private static final long serialVersionUID = 1L;
 
 		public CommonTokenWithText(String tokenText, int type, int defaultChannel, int offset) {
-			super(null, type, defaultChannel, offset, offset + tokenText.length() - 1);
+			this(tokenText, type, defaultChannel, offset, offset + tokenText.length() - 1);
+		}
+		
+		public CommonTokenWithText(String tokenText, int type, int defaultChannel, int offset, int end) {
+			super(null, type, defaultChannel, offset, end);
 			this.text = tokenText;
 		}
 	}

--- a/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/YangParsingTest.xtend
+++ b/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/YangParsingTest.xtend
@@ -333,6 +333,54 @@ class YangParsingTest {
 		  type or:origin-ref;
 		}'''.wrapModule.assertNoParserErrors;
 	}
+	@Test
+	def void testIssue_113_01() {
+		val model = '''
+		path "/qosipose-"
+		+ "map/name"'''.wrapModule.parse
+
+		assertEquals(
+		'''
+		XpathLocation {
+		    cref XpathExpression target AbsolutePath {
+		        cref XpathStep step XpathStep {
+		            cref XpathNodeTest node XpathNameTest {
+		                ref SchemaNode ref ref: SchemaNode@(unresolved proxy __synthetic0.yang#|0)
+		            }
+		        }
+		    }
+		    cref XpathStep step XpathStep {
+		        cref XpathNodeTest node XpathNameTest {
+		            ref SchemaNode ref ref: SchemaNode@(unresolved proxy __synthetic0.yang#|1)
+		        }
+		    }
+		}'''.toString,
+			EmfFormatter.objToStr((model.substatements.head as Path).reference).toPlatformLineSeparator)
+	}
+	@Test
+	def void testIssue_113_02() {
+		val model = '''
+		path "/qosipose-map"
+		+ "/name"'''.wrapModule.parse
+
+		assertEquals(
+		'''
+		XpathLocation {
+		    cref XpathExpression target AbsolutePath {
+		        cref XpathStep step XpathStep {
+		            cref XpathNodeTest node XpathNameTest {
+		                ref SchemaNode ref ref: SchemaNode@(unresolved proxy __synthetic0.yang#|0)
+		            }
+		        }
+		    }
+		    cref XpathStep step XpathStep {
+		        cref XpathNodeTest node XpathNameTest {
+		            ref SchemaNode ref ref: SchemaNode@(unresolved proxy __synthetic0.yang#|1)
+		        }
+		    }
+		}'''.toString,
+			EmfFormatter.objToStr((model.substatements.head as Path).reference).toPlatformLineSeparator)
+	}
 
 	private def wrapModule(CharSequence it) '''
 		module foo {

--- a/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/serializer/ModuleSerializeTest.xtend
+++ b/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/serializer/ModuleSerializeTest.xtend
@@ -94,6 +94,8 @@ class ModuleSerializeTest {
 					prefix ytest;
 				}
 				container cb {
+			        must "number(.) <= number(lb/list-leaf-"
+			        +"c/leafref)";
 				    list lb {
 				        leaf lfb {
 				            type leafref {
@@ -114,6 +116,16 @@ class ModuleSerializeTest {
 				        	type leafref { 
 				        		path "/ytest:" + "c1/ytest" + ":l1";
 				        	}
+				        }
+				        leaf list-leaf-c {
+				            type leafref {
+				                path "/ytest:cont-one/ytest:leaf-one";
+				            }
+				        }
+				        leaf list-leaf-c2 {
+				            type leafref {
+				                path "/ytest:cont-" +/ytest:leaf" + "-one";
+				            }
 				        }
 				    }
 				}
@@ -249,7 +261,11 @@ class ModuleSerializeTest {
 			        }
 			        t:suppress-echo true;
 			    }
-				
+				container cont-one {
+				    leaf leaf-one {
+				        type string;
+				    }
+				}
 				container c2 {
 				t:callpoint is-system-created-cb {
 			            t:set-hook node;

--- a/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/serializer/ModuleSerializeTest.xtend
+++ b/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/serializer/ModuleSerializeTest.xtend
@@ -86,84 +86,108 @@ class ModuleSerializeTest {
 	def void testSerializeOriginalXPath() {
 		val targetModule = loadModuleFile("xpath-serialize.yang")
 		assertSerialized('''
-			module xpath-serialize {
-				namespace xpath;
-				prefix xs;
-				yang-version 1.1;
-				import yangster-test {
-					prefix ytest;
-				}
-				container cb {
-			        must "number(.) <= number(lb/list-leaf-"
-			        +"c/leafref)";
-				    list lb {
-				        leaf lfb {
-				            type leafref {
-				                path "/ytest:c1/ytest:l1";
-				            }
-				        }
-				        leaf lfb2 { 
-				        	type leafref { 
-				        		path "/ytest:c1" + "/ytest:l1";
-				        	}
-				        }
-				        leaf lfb3 { 
-				        	type leafref { 
-				        		path "/ytest:c1/" + "ytest:l1";
-				        	}
-				        }
-				        leaf lfb4 { 
-				        	type leafref { 
-				        		path "/ytest:" + "c1/ytest" + ":l1";
-				        	}
-				        }
-				        leaf list-leaf-c {
-				            type leafref {
-				                path "/ytest:cont-one/ytest:leaf-one";
-				            }
-				        }
-				        leaf list-leaf-c2 {
-				            type leafref {
-				                path "/ytest:cont-" +/ytest:leaf" + "-one";
-				            }
-				        }
-				    }
-				}
-			}
+		module xpath-serialize {
+		    namespace xpath;
+		    prefix xs;
+		    yang-version 1.1;
+		    import yangster-test {
+		        prefix ytest;
+		    }
+		    container cb {
+		        must "number(.) <= number(lb/list-leaf-"
+		        +"c/leafref)";
+		
+		        list lb {
+		            leaf lfb {
+		                type leafref {
+		                    path "/ytest:c1/ytest:l1";
+		                }
+		            }
+		            leaf lfb2 {
+		                type leafref {
+		                    path "/ytest:c1" + "/ytest:l1";
+		                }
+		            }
+		            leaf lfb3 {
+		                type leafref {
+		                    path "/ytest:c1/" + "ytest:l1";
+		                }
+		            }
+		            leaf lfb4 {
+		                type leafref {
+		                    path "/ytest:" + "c1/ytest" + ":l1";
+		                }
+		            }
+		            leaf list-leaf-c {
+		                type leafref {
+		                    path "/ytest:cont-one/ytest:leaf-one";
+		                }
+		            }
+		            leaf list-leaf-c2 {
+		                type leafref {
+		                    path "/ytest:cont-" + "one/ytest:leaf" + "-one";
+		                }
+		            }
+		            leaf list-leaf-c3 {
+		                type leafref {
+		                    path "/ytest:cont-" + "one/ytest:" + "leaf" + "-one";
+		                }
+		            }
+		        }
+		    }
+		}
 		''', targetModule, false)
 		EcoreUtil.resolveAll(targetModule)
 		assertSerialized('''
 			module xpath-serialize {
-				namespace xpath;
-				prefix xs;
-				yang-version 1.1;
-				import yangster-test {
-					prefix ytest;
-				}
-				container cb {
-				    list lb {
-				        leaf lfb {
-				            type leafref {
-				                path "/ytest:c1/ytest:l1";
-				            }
-				        }
-				        leaf lfb2 { 
-				        	type leafref { 
-				        		path "/ytest:c1" + "/ytest:l1";
-				        	}
-				        }
-				        leaf lfb3 { 
-				        	type leafref { 
-				        		path "/ytest:c1/" + "ytest:l1";
-				        	}
-				        }
-				        leaf lfb4 { 
-				        	type leafref { 
-				        		path "/ytest:" + "c1/ytest" + ":l1";
-				        	}
-				        }
-				    }
-				}
+			    namespace xpath;
+			    prefix xs;
+			    yang-version 1.1;
+			    import yangster-test {
+			        prefix ytest;
+			    }
+			    container cb {
+			        must "number(.) <= number(lb/list-leaf-"
+			        +"c/leafref)";
+			
+			        list lb {
+			            leaf lfb {
+			                type leafref {
+			                    path "/ytest:c1/ytest:l1";
+			                }
+			            }
+			            leaf lfb2 {
+			                type leafref {
+			                    path "/ytest:c1" + "/ytest:l1";
+			                }
+			            }
+			            leaf lfb3 {
+			                type leafref {
+			                    path "/ytest:c1/" + "ytest:l1";
+			                }
+			            }
+			            leaf lfb4 {
+			                type leafref {
+			                    path "/ytest:" + "c1/ytest" + ":l1";
+			                }
+			            }
+			            leaf list-leaf-c {
+			                type leafref {
+			                    path "/ytest:cont-one/ytest:leaf-one";
+			                }
+			            }
+			            leaf list-leaf-c2 {
+			                type leafref {
+			                    path "/ytest:cont-" + "one/ytest:leaf" + "-one";
+			                }
+			            }
+			            leaf list-leaf-c3 {
+			                type leafref {
+			                    path "/ytest:cont-" + "one/ytest:" + "leaf" + "-one";
+			                }
+			            }
+			        }
+			    }
 			}
 		''', targetModule, false)
 	}

--- a/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/xpath/XpathResolverTest.xtend
+++ b/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/xpath/XpathResolverTest.xtend
@@ -193,4 +193,26 @@ class XpathResolverTest extends AbstractYangTest {
 		assertNoErrors(r.root)
 	}
 	
+	@Test def void testConcatPath() {
+		val r = '''
+			module bug_113 {
+			    prefix bug_113;
+			    namespace bug_113;
+			    list l1-list1 {
+			        leaf lf1-list2 {
+			            type string;
+			        }
+			    }
+			    container test {
+			        must "/l1-" 
+			        +  "list1";
+			    }
+			    container test2 {
+			        must "/l1-"+"list1" + "/lf1-"+"list2";
+			    }
+			}
+		'''.load
+		assertNoErrors(r.root)
+	}
+	
 }

--- a/yang-lsp/io.typefox.yang/src/test/resources/bug_114.yang
+++ b/yang-lsp/io.typefox.yang/src/test/resources/bug_114.yang
@@ -1,14 +1,31 @@
 module bug_114 {
     prefix bug_114;
     namespace bug_114;
-    list l1 {
-        leaf lf1 {
+    list l1-list1 {
+        leaf lf1-list2 {
             type string;
         }
     }
-    deviation l1 {
+
+    container test {
+        must "/l1-" + "list1";
+        
+    }
+    container test2 {
+        must "/l1-" + "list1" + "/lf1-list2";
+        
+    }
+     container test3 {
+        must "/l1-list1";
+        
+    }
+     container test4 {
+        must "/l1-list1" + "/lf1-list2";
+        
+    }
+    deviation l1-list1 {
         deviate add {
-            unique lf1;
+            unique  "lf1-list2";
         }
     }
 }

--- a/yang-lsp/io.typefox.yang/src/test/resources/xpath-serialize.yang
+++ b/yang-lsp/io.typefox.yang/src/test/resources/xpath-serialize.yang
@@ -1,45 +1,50 @@
 module xpath-serialize {
-	namespace xpath;
-	prefix xs;
-	yang-version 1.1;
-	import yangster-test {
-		prefix ytest;
-	}
-	container cb {
+    namespace xpath;
+    prefix xs;
+    yang-version 1.1;
+    import yangster-test {
+        prefix ytest;
+    }
+    container cb {
         must "number(.) <= number(lb/list-leaf-"
         +"c/leafref)";
-        
-	    list lb {
-	        leaf lfb {
-	            type leafref {
-	                path "/ytest:c1/ytest:l1";
-	            }
-	        }
-	        leaf lfb2 { 
-	        	type leafref { 
-	        		path "/ytest:c1" + "/ytest:l1";
-	        	}
-	        }
-	        leaf lfb3 { 
-	        	type leafref { 
-	        		path "/ytest:c1/" + "ytest:l1";
-	        	}
-	        }
-	        leaf lfb4 { 
-	        	type leafref { 
-	        		path "/ytest:" + "c1/ytest" + ":l1";
-	        	}
-	        }
-	        leaf list-leaf-c {
-	            type leafref {
-	                path "/ytest:cont-one/ytest:leaf-one";
-	            }
-	        }
-	        leaf list-leaf-c2 {
-	            type leafref {
-	                path "/ytest:cont-" + "one/ytest:leaf" + "-one";
-	            }
-	        }
-	    }
-	}
+
+        list lb {
+            leaf lfb {
+                type leafref {
+                    path "/ytest:c1/ytest:l1";
+                }
+            }
+            leaf lfb2 {
+                type leafref {
+                    path "/ytest:c1" + "/ytest:l1";
+                }
+            }
+            leaf lfb3 {
+                type leafref {
+                    path "/ytest:c1/" + "ytest:l1";
+                }
+            }
+            leaf lfb4 {
+                type leafref {
+                    path "/ytest:" + "c1/ytest" + ":l1";
+                }
+            }
+            leaf list-leaf-c {
+                type leafref {
+                    path "/ytest:cont-one/ytest:leaf-one";
+                }
+            }
+            leaf list-leaf-c2 {
+                type leafref {
+                    path "/ytest:cont-" + "one/ytest:leaf" + "-one";
+                }
+            }
+            leaf list-leaf-c3 {
+                type leafref {
+                    path "/ytest:cont-" + "one/ytest:" + "leaf" + "-one";
+                }
+            }
+        }
+    }
 }

--- a/yang-lsp/io.typefox.yang/src/test/resources/xpath-serialize.yang
+++ b/yang-lsp/io.typefox.yang/src/test/resources/xpath-serialize.yang
@@ -6,6 +6,9 @@ module xpath-serialize {
 		prefix ytest;
 	}
 	container cb {
+        must "number(.) <= number(lb/list-leaf-"
+        +"c/leafref)";
+        
 	    list lb {
 	        leaf lfb {
 	            type leafref {
@@ -26,6 +29,16 @@ module xpath-serialize {
 	        	type leafref { 
 	        		path "/ytest:" + "c1/ytest" + ":l1";
 	        	}
+	        }
+	        leaf list-leaf-c {
+	            type leafref {
+	                path "/ytest:cont-one/ytest:leaf-one";
+	            }
+	        }
+	        leaf list-leaf-c2 {
+	            type leafref {
+	                path "/ytest:cont-" + "one/ytest:leaf" + "-one";
+	            }
 	        }
 	    }
 	}

--- a/yang-lsp/io.typefox.yang/src/test/resources/yangster-test.yang
+++ b/yang-lsp/io.typefox.yang/src/test/resources/yangster-test.yang
@@ -18,7 +18,11 @@ module yangster-test {
 			type string;
 		}
 	}
-	
-	container c2 {
+	container cont-one {
+        leaf leaf-one {
+            type string;
+        }
+	}
+    container c2 {
 	}
 }


### PR DESCRIPTION
In some generated files the XPath is concatenated  inside an identifier see #113 

This fix squashes tokens in case of <ID>" + "<ID> (`"+"` is represented as two hidden tokens from `STRING_CONCAT` ) in one <ID> token 